### PR TITLE
fix: prevent CRS corruption and add large-file warnings (audit fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2026-02-12
+
+### Fixed
+- **Critical**: `ensure_wgs84()` now raises `ValueError` when input data has no CRS defined, instead of silently assuming EPSG:4326. This prevents coordinate corruption when projected data (e.g. UTM) is loaded without a `.prj` file. (OVC-001 from audit)
+- **UX**: GeoPackage writer now logs a warning when a layer has no CRS, instead of silently setting EPSG:4326.
+- **UX**: Building and road loaders now warn when file size exceeds 500 MB or feature count exceeds 100,000, setting expectations for runtime and memory usage.
+
+### Added
+- 9 new tests in `tests/test_crs.py` covering `ensure_wgs84`, `choose_utm_crs_from_gdf`, and `get_crs_pair` with valid, projected, missing, and edge-case CRS inputs.
+
 ## [3.1.0] - 2026-02-11
 
 ### Added

--- a/ovc/core/crs.py
+++ b/ovc/core/crs.py
@@ -22,8 +22,24 @@ def choose_utm_crs_from_gdf(gdf_4326: gpd.GeoDataFrame) -> CRS:
 
 
 def ensure_wgs84(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """Reproject a GeoDataFrame to WGS 84 (EPSG:4326).
+
+    Raises
+    ------
+    ValueError
+        If the GeoDataFrame has no CRS defined.  OVC requires
+        georeferenced data to prevent silent coordinate corruption.
+
+        Previously this function silently assumed ``EPSG:4326`` when
+        ``crs`` was ``None``, which could produce incorrect QC results
+        if the data was actually in a projected CRS.
+    """
     if gdf.crs is None:
-        return gdf.set_crs(4326)
+        raise ValueError(
+            "Input data has no CRS defined. OVC requires georeferenced data. "
+            "Set the CRS in your source file (e.g. via QGIS or ogr2ogr), "
+            "or run 'geoqa profile <file>' to diagnose the issue."
+        )
     return gdf.to_crs(4326)
 
 

--- a/ovc/export/geopackage.py
+++ b/ovc/export/geopackage.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
+
 import geopandas as gpd
+
+logger = logging.getLogger("ovc.export.geopackage")
 
 
 def _write_layer(gpkg_path: Path, layer: str, gdf: gpd.GeoDataFrame) -> None:
@@ -9,6 +13,11 @@ def _write_layer(gpkg_path: Path, layer: str, gdf: gpd.GeoDataFrame) -> None:
         return
     gpkg_path.parent.mkdir(parents=True, exist_ok=True)
     if gdf.crs is None:
+        logger.warning(
+            "Layer '%s' has no CRS — writing with EPSG:4326 assumed. "
+            "This may produce incorrect results if the data is not in WGS 84.",
+            layer,
+        )
         gdf = gdf.set_crs(4326)
     gdf.to_file(gpkg_path, layer=layer, driver="GPKG")
 

--- a/ovc/loaders/buildings.py
+++ b/ovc/loaders/buildings.py
@@ -34,6 +34,14 @@ def load_buildings(path: Path) -> gpd.GeoDataFrame:
     if not path.exists():
         raise FileNotFoundError(f"Buildings file not found: {path}")
 
+    # Warn about large files before loading
+    file_size_mb = path.stat().st_size / 1e6
+    if file_size_mb > 500:
+        logger.warning(
+            f"Large buildings file ({file_size_mb:.0f} MB) — "
+            "loading may be slow and require significant memory"
+        )
+
     logger.info(f"Loading buildings from {path}")
     gdf = gpd.read_file(path)
 
@@ -57,6 +65,12 @@ def load_buildings(path: Path) -> gpd.GeoDataFrame:
         gdf["osmid"] = gdf.index.astype(str)
     else:
         gdf["osmid"] = gdf["osmid"].astype(str)
+
+    if len(gdf) > 100_000:
+        logger.warning(
+            f"Large dataset ({len(gdf):,} buildings) — "
+            "QC checks may take several minutes"
+        )
 
     logger.info(f"Loaded {len(gdf)} buildings")
     return gdf

--- a/ovc/loaders/roads.py
+++ b/ovc/loaders/roads.py
@@ -39,6 +39,14 @@ def load_roads(
     if not path.exists():
         raise FileNotFoundError(f"Roads file not found: {path}")
 
+    # Warn about large files before loading
+    file_size_mb = path.stat().st_size / 1e6
+    if file_size_mb > 500:
+        logger.warning(
+            f"Large roads file ({file_size_mb:.0f} MB) — "
+            "loading may be slow and require significant memory"
+        )
+
     logger.info(f"Loading roads from {path}")
     gdf = gpd.read_file(path)
 
@@ -71,6 +79,12 @@ def load_roads(
         gdf["osmid"] = gdf.index.astype(str)
     else:
         gdf["osmid"] = gdf["osmid"].astype(str)
+
+    if len(gdf) > 100_000:
+        logger.warning(
+            f"Large dataset ({len(gdf):,} road features) — "
+            "QC checks may take several minutes"
+        )
 
     gdf["feature_type"] = "road"
     logger.info(f"Loaded {len(gdf)} road features")

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -1,0 +1,99 @@
+"""Tests for CRS validation in ovc.core.crs."""
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point, Polygon
+
+from ovc.core.crs import choose_utm_crs_from_gdf, ensure_wgs84, get_crs_pair
+
+
+class TestEnsureWgs84:
+    """Tests for ensure_wgs84 — the central CRS gate."""
+
+    def test_raises_on_no_crs(self):
+        """ensure_wgs84 must raise ValueError when CRS is None."""
+        gdf = gpd.GeoDataFrame(
+            {"val": [1]},
+            geometry=[Point(31.0, 30.0)],
+        )
+        assert gdf.crs is None
+        with pytest.raises(ValueError, match="no CRS defined"):
+            ensure_wgs84(gdf)
+
+    def test_valid_projected_crs_reprojected(self):
+        """Data in a projected CRS should be reprojected to EPSG:4326."""
+        gdf = gpd.GeoDataFrame(
+            {"val": [1]},
+            geometry=[Point(500_000, 3_300_000)],
+            crs="EPSG:32636",  # UTM zone 36N
+        )
+        result = ensure_wgs84(gdf)
+        assert result.crs is not None
+        assert result.crs.to_epsg() == 4326
+
+    def test_already_wgs84(self):
+        """Data already in EPSG:4326 should pass through unchanged."""
+        gdf = gpd.GeoDataFrame(
+            {"val": [1]},
+            geometry=[Point(31.0, 30.0)],
+            crs="EPSG:4326",
+        )
+        result = ensure_wgs84(gdf)
+        assert result.crs.to_epsg() == 4326
+        assert float(result.geometry.iloc[0].x) == pytest.approx(31.0, abs=1e-6)
+
+    def test_web_mercator_reprojected(self):
+        """EPSG:3857 (Web Mercator) should be reprojected to 4326."""
+        gdf = gpd.GeoDataFrame(
+            {"val": [1]},
+            geometry=[Point(0, 0)],
+            crs="EPSG:3857",
+        )
+        result = ensure_wgs84(gdf)
+        assert result.crs.to_epsg() == 4326
+
+
+class TestChooseUtmCrs:
+    """Tests for choose_utm_crs_from_gdf."""
+
+    def test_egypt_utm_zone(self):
+        """Data near Cairo should get UTM zone 36N."""
+        gdf = gpd.GeoDataFrame(
+            geometry=[Point(31.2, 30.0)],
+            crs="EPSG:4326",
+        )
+        utm = choose_utm_crs_from_gdf(gdf)
+        assert utm.to_epsg() == 32636
+
+    def test_empty_gdf_fallback(self):
+        """Empty GDF should return Web Mercator fallback."""
+        gdf = gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
+        utm = choose_utm_crs_from_gdf(gdf)
+        assert utm.to_epsg() == 3857
+
+    def test_none_gdf_fallback(self):
+        """None input should return Web Mercator fallback."""
+        utm = choose_utm_crs_from_gdf(None)
+        assert utm.to_epsg() == 3857
+
+
+class TestGetCrsPair:
+    """Tests for get_crs_pair."""
+
+    def test_returns_wgs84_and_utm(self):
+        gdf = gpd.GeoDataFrame(
+            geometry=[Polygon([(31, 30), (31.1, 30), (31.1, 30.1), (31, 30.1)])],
+            crs="EPSG:4326",
+        )
+        pair = get_crs_pair(gdf)
+        assert pair.crs_wgs84.to_epsg() == 4326
+        # UTM zone for lon=31 → zone 36
+        assert pair.crs_metric.to_epsg() == 32636
+
+    def test_raises_on_no_crs(self):
+        """get_crs_pair should propagate the ValueError from ensure_wgs84."""
+        gdf = gpd.GeoDataFrame(
+            geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+        )
+        with pytest.raises(ValueError, match="no CRS defined"):
+            get_crs_pair(gdf)


### PR DESCRIPTION
## Summary
- **Critical**: ensure_wgs84() now raises ValueError when input data has no CRS defined, instead of silently assuming EPSG:4326. This prevents coordinate corruption when projected data (e.g. UTM) is loaded without a .prj file. (OVC-001 from audit)
- **UX**: GeoPackage writer logs a warning when a layer has no CRS.
- **UX**: Building and road loaders warn when file size exceeds 500 MB or feature count exceeds 100,000.

## Files changed
- ovc/core/crs.py: CRS validation in ensure_wgs84()
- ovc/export/geopackage.py: Warning instead of silent set_crs
- ovc/loaders/buildings.py: File size and feature count warnings
- ovc/loaders/roads.py: File size and feature count warnings
- tests/test_crs.py: 9 new tests
- CHANGELOG.md: v3.1.1 entry

## Test plan
- 50/50 tests pass (41 original + 9 new)
- No regressions in existing tests
- New test: ensure_wgs84 raises on None CRS
- New test: ensure_wgs84 reprojections (UTM, Web Mercator, 4326)
- New test: get_crs_pair propagates error
- New test: choose_utm_crs edge cases

See audit report: docs/audit/BUGS_FOUND.md
